### PR TITLE
Fix embedding init for unmatched base tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ python remap_tokenizer.py \
 Result:
 
 * `./swallow-r1-tokenfixed/` contains a re-sharded `safetensors` model and a **patched tokenizer** whose vocab size ≥ R1.
+* Base tokens that were missing from the source model are initialized with the `<unk>` vector.
 
 ### 2.2 Drop-mode (`--drop-extra`)
 

--- a/remap_tokenizer.py
+++ b/remap_tokenizer.py
@@ -128,8 +128,15 @@ def main(
                 token_str = tokenizer_src.convert_ids_to_tokens(src_id)
                 dst_id = tokenizer_base.convert_tokens_to_ids(token_str)
                 if dst_id is None or dst_id < 0:
-                    raise ValueError(f"Token '{token_str}' (id={src_id}) cannot be mapped to base tokenizer.")
+                    raise ValueError(
+                        f"Token '{token_str}' (id={src_id}) cannot be mapped to base tokenizer."
+                    )
                 id_map[src_id] = dst_id
+
+            # Initialize all rows with the unknown vector in case the base tokenizer
+            # contains tokens that are absent from the source model
+            new_embed[:] = unk_vec_embed
+            new_lm[:] = unk_vec_lm
 
             # Scatter the embeddings and lm weights to new tensors
             new_embed[id_map] = embed_weights


### PR DESCRIPTION
## Summary
- initialize embeddings for base-only tokens with the unk vector
- document this detail in README

## Testing
- `python -m py_compile compare_tokenizers.py remap_tokenizer.py`

------
https://chatgpt.com/codex/tasks/task_e_683f7f4e77f083238f9f86ec2e9f165b